### PR TITLE
Clarify interop eth1data hashing

### DIFF
--- a/interop/mocked_eth1data/README.md
+++ b/interop/mocked_eth1data/README.md
@@ -14,8 +14,9 @@ This has validators agreeing upon a stubbed `deposit_root` and `block_hash` but 
 def get_eth1data_stub(state: BeaconState, current_epoch: Epoch) -> Eth1Data:
     epochs_per_period = SLOTS_PER_ETH1_VOTING_PERIOD // SLOTS_PER_EPOCH
     voting_period = current_epoch // epochs_per_period
+    deposit_root = hash(int_to_bytes(voting_period, length=32))
     return Eth1Data(
-        deposit_root=hash(voting_period),
+        deposit_root=deposit_root,
         deposit_count=state.eth1_deposit_index,
-        block_hash=hash(hash(voting_period)),
+        block_hash=hash(deposit_root),
     )


### PR DESCRIPTION
Specifies how `voting_period` should be serialized before hashing.